### PR TITLE
Fix/csv file write does not generate csv

### DIFF
--- a/tests/test_write_file.py
+++ b/tests/test_write_file.py
@@ -4,6 +4,7 @@
 
 import unittest
 import pytest
+import csv
 from unittest.mock import patch, mock_open
 from io import StringIO
 from xsniper.csv_file import CSVFile
@@ -33,4 +34,6 @@ def test_write_called_with_content(set_csv_file):
     with patch('xsniper.csv_file.open', mock_open()) as mocked_file:
         got.write(fake_file_path)
 
-    mocked_file().write.assert_called_once_with(got.content)
+    called_number = mocked_file().write.call_count
+
+    assert called_number == 3

--- a/tests/test_write_file.py
+++ b/tests/test_write_file.py
@@ -4,7 +4,6 @@
 
 import unittest
 import pytest
-import csv
 from unittest.mock import patch, mock_open
 from io import StringIO
 from xsniper.csv_file import CSVFile

--- a/xsniper/csv_file.py
+++ b/xsniper/csv_file.py
@@ -78,7 +78,8 @@ class CSVFile:
             file_path: a string corresponding to file to edit.
         """
         with open(file_path, 'w') as file:
-            file.write(self.content)
+            writer = csv.writer(file)
+            writer.writerows(self.content)
 
     def add_value(self, cell, header, value):
         """Add a value (a cell) based on another cell in the same row


### PR DESCRIPTION
## Proposed changes

`CSVFile.write()` use `csv.writer()` to convert list (`CSVFile.content`) to csv file format.
See:
```python
    def write(self, file_path):
        """Write self.content to file path.

        Args:
            file_path: a string corresponding to file to edit.
        """
        with open(file_path, 'w') as file:
            writer = csv.writer(file)
            writer.writerows(self.content
```

fix #25 

## Types of changes

What types of changes does your code introduce to the project?
_Put an  in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor

## Checklist

_Put an  in the boxes that apply. You can also fill these out after creating the PR._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining
why you chose the solution you did and what alternatives you considered, etc...
